### PR TITLE
Update HipChatHandler.php

### DIFF
--- a/src/Monolog/Handler/HipChatHandler.php
+++ b/src/Monolog/Handler/HipChatHandler.php
@@ -205,8 +205,12 @@ class HipChatHandler extends SocketHandler
      */
     protected function write(array $record)
     {
-        parent::write($record);
-        $this->closeSocket();
+        try{
+            parent::write($record);
+            $this->closeSocket();
+        } catch (\Exception $e){
+            // socket creation failed. Cannot connect to hipchat API.
+        }
     }
 
     /**


### PR DESCRIPTION
In case the connection with HipChat API cannot be established, logging with this handler would throw an exception. Wrapping the call in a try-catch prevents this.